### PR TITLE
fix(opencommit): scope GITHUB_TOKEN permissions to least privilege

### DIFF
--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -15,7 +15,9 @@ jobs:
         name: OpenCommit
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions: write-all
+        permissions:
+            contents: write
+            pull-requests: write
         steps:
             - name: Setup Node.js Environment
               uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- `.github/workflows/opencommit.yml` granted `permissions: write-all` to the `GITHUB_TOKEN`, which is far broader than the job needs.
- Narrowed to `contents: write` (push amended commits) and `pull-requests: write` (the only things this action does).

## Test plan
- [x] YAML validated
- [ ] OpenCommit run on this PR/branch still succeeds with the narrower permissions